### PR TITLE
Redesign website with accessibility in mind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.jekyll-cache
+_site

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,8 +3,9 @@
         <div class="container">
             <div class="row">
                 <div class="col-md-4 col-md-offset-4">
-                    <img width="100%" class="alleen-samen" src="img/alleen-samen.svg" alt="alleen samen krijgen we corona onder controle" />
-                 </div>
+                    <img width="100%" class="alleen-samen" src="img/alleen-samen.svg"
+                        alt="alleen samen krijgen we corona onder controle" />
+                </div>
             </div>
         </div>
     </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <header class="header" role="banner">
     <div class="header-logo">
         <a href="." title="{{ site.data.translations.minvwslogo[page.lang] }}">
-            <span class="screenreader-only">{{ site.data.translations.minvws[page.lang] }}</span>
+            <span role="img" class="screenreader-only">{{ site.data.translations.minvws[page.lang] }}</span>
         </a>
     </div>
 </header>
@@ -9,7 +9,7 @@
     <div class="container">
         <ul class="nav">
             <li class="nav__item">
-                <a class="nav__link nav__link--active" href=".">{{ site.data.translations.community[page.lang] }}</a>
+                <a class="nav__link nav__link--active" href="." aria-current="page">{{ site.data.translations.community[page.lang] }}</a>
             </li>
             <li class="nav__item">
                 <a class="nav__link" href="{{ site.data.translations.statuslink[page.lang] }}"

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,27 +1,19 @@
 <header class="header" role="banner">
     <div class="header-logo">
-         <a href="." title="{{ site.data.translations.minvwslogo[page.lang] }}">
+        <a href="." title="{{ site.data.translations.minvwslogo[page.lang] }}">
             <span class="screenreader-only">{{ site.data.translations.minvws[page.lang] }}</span>
-         </a>
+        </a>
     </div>
 </header>
-<nav class="top-nav top-nav--geel image-background">
-    <div class="container">
-        <div class="content-background">
-            <div class="content">
-                <header class="content__header">
-                    <h1 class="content__header-title">{% if page.title %}{{ page.title }}{% else %}{{ site.data.translations.title[page.lang] }}{% endif %}</h1>
-                    <p class="content__header-paragraph">{% if page.subtitle %}{{ page.subtitle }}{% else %}{{ site.data.translations.description[page.lang] }}{% endif %}</p>
-                </header>
-            </div>
-        </div>
-    </div>
+<nav class="top-nav top-nav--geel">
     <div class="container">
         <ul class="nav">
             <li class="nav__item">
-                <a class="nav__link nav__link--active" href=".">{{ site.data.translations.community[page.lang] }}</a></li>
+                <a class="nav__link nav__link--active" href=".">{{ site.data.translations.community[page.lang] }}</a>
+            </li>
             <li class="nav__item">
-                <a class="nav__link" href="{{ site.data.translations.statuslink[page.lang] }}" rel="external">{{ site.data.translations.status[page.lang] }}</a></li>
+                <a class="nav__link" href="{{ site.data.translations.statuslink[page.lang] }}"
+                    rel="external">{{ site.data.translations.status[page.lang] }}</a></li>
         </ul>
     </div>
 </nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,7 +13,7 @@
         <div class="hero image-background background--violet">
         <div class="container">
             <header class="row">
-                <div class="col-md-12">
+                <div class="col-md-offset-1 col-md-10">
                     <div class="content">
                         <section class="content-header">
                             <h1 class="content__header-title">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,13 +6,33 @@
 <!-- generated at {{ site.time }} -->
 <html lang="{{ page.lang }}">
 {% include head.html %}
+
 <body>
     {% include header.html %}
     <main class="skiplink-target main" id="content" tabindex="-1">
+        <div class="hero image-background background--violet">
+        <div class="container">
+            <header class="row">
+                <div class="col-md-12">
+                    <div class="content">
+                        <section class="content-header">
+                            <h1 class="content__header-title">
+                                {% if page.title %}{{ page.title }}{% else %}{{ site.data.translations.title[page.lang] }}{% endif %}
+                            </h1>
+                            <p class="content__header-paragraph">
+                                {% if page.subtitle %}{{ page.subtitle }}{% else %}{{ site.data.translations.description[page.lang] }}{% endif %}
+                            </p>
+                        </section>
+                    </div>
+                </div>
+            </header>
+        </div>
+        </div>
         <div class="container">
             {{ content }}
         </div>
     </main>
     {% include footer.html %}
 </body>
+
 </html>

--- a/css/main.css
+++ b/css/main.css
@@ -5,6 +5,11 @@
     background-position: 105% 30%;
     background-size: 55%;
 }
+@media (max-width: 768px) {
+    .image-background {
+        background-image: none;
+    }
+}
 .header-logo a::before {
     background: url('../img/logo.svg') no-repeat bottom;
 }
@@ -30,14 +35,15 @@
 .icon-trello {
     background-image: url("../img/trello-mark-white.svg");
 }
-@media (max-width: 992px) {
-  .top-nav > .container > .content-background {
-    margin-bottom: 0rem;
-  }
-}
 
 .footer__content {
   color: black;
   background: #ffb612; /* Workaround bug in UNO */
 }
 
+.hero {
+    margin-top: -2rem;
+    padding-top: 6rem;
+    padding-bottom: 6rem;
+    margin-bottom: 2rem;
+}

--- a/index.md
+++ b/index.md
@@ -6,31 +6,33 @@ lang-ref: covid19-notification-app-community-index
 
 {% assign blocks = site.blocks | where: "lang", page.lang | sort: "index" %}
 {% assign rows = blocks.size | divided_by: 2.0 | ceil %}
-<div class="cols">
 {% for block in blocks %}
-<div class="col-md-12">
-      <div class="content-background">
-          <div class="content">
-              <header class="content__header">
-                  <h1 class="content__header-title">{{ block.title }}</h1>
-                  <p class="content__header-paragraph">{{ block.subtitle }}</p>
-              </header>
-              {{ block.content }}
-              {% if block.list %}
-              <ul class="list list--subjects columns">
-                  {% for item in block.list %}
-                  <li class="list__item">
-                      <a href="{{ item.href }}" class="list__link">{{ item.title }}</a><br>
-                      <p>{{ item.text }}</p>
-                  </li>
-                  {% endfor %}
-              </ul>
-              {% endif %}
-              {% if block.button %}
-              <a class="btn" href="{{ block.button.href }}" rel="external">{{ block.button.text }}{% if block.button.icon %}<span class="icon icon-{{ block.button.icon }}"></span>{% endif %}</a>
-              {% endif %}
-          </div>
-      </div>
+<div class="row">
+    <div class="col-md-12">
+        <div class="content-background">
+            <div class="content">
+                <header class="content__header">
+                    <h2 class="content__header-title">{{ block.title }}</h2>
+                    <p class="content__header-paragraph">{{ block.subtitle }}</p>
+                </header>
+                {{ block.content }}
+                {% if block.list %}
+                <ul class="list list--subjects columns">
+                    {% for item in block.list %}
+                    <li class="list__item">
+                        <a href="{{ item.href }}" class="list__link">{{ item.title }}</a><br>
+                        <p>{{ item.text }}</p>
+                    </li>
+                    {% endfor %}
+                </ul>
+                {% endif %}
+                {% if block.button %}
+                <a class="btn" href="{{ block.button.href }}"
+                    rel="external">{{ block.button.text }}{% if block.button.icon %}<span
+                        class="icon icon-{{ block.button.icon }}"></span>{% endif %}</a>
+                {% endif %}
+            </div>
+        </div>
+    </div>
 </div>
 {% endfor %}
-</div>

--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ lang-ref: covid19-notification-app-community-index
 {% assign rows = blocks.size | divided_by: 2.0 | ceil %}
 {% for block in blocks %}
 <div class="row">
-    <div class="col-md-12">
+    <div class="col-md-offset-1 col-md-10">
         <div class="content-background">
             <div class="content">
                 <header class="content__header">


### PR DESCRIPTION
Header moved into main; use a Hero element instead of title above navbar
This should make the content more accessible for screen-readers. 

Website now takes more liberties with the original design, but it's better for accessibility.

Added screenshots of the new look. Don't know how to render a preview of the HTML with github pages in a PR, so let me find something for that so that somebody can check if the markup is now better for screen readers.

![image](https://user-images.githubusercontent.com/628387/85159641-122f9680-b25e-11ea-9e62-cdb2e8aec839.png)
![image](https://user-images.githubusercontent.com/628387/85159815-40ad7180-b25e-11ea-8c6f-ef89e492a9d9.png)

![image](https://user-images.githubusercontent.com/628387/85159759-34291900-b25e-11ea-81d5-35f367d02b50.png)

